### PR TITLE
Address ruby 2.7 keyword argument warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 group :development do
   gem "coveralls", require: false
-  gem "faraday", "0.15.4"
+  gem "faraday", "0.17.3"
   gem "mocha", "~> 0.13.2"
   gem "rake"
   gem "shoulda-context"

--- a/lib/telnyx/api_resource.rb
+++ b/lib/telnyx/api_resource.rb
@@ -72,7 +72,7 @@ module Telnyx
 
     def self.retrieve(id, opts = {})
       opts = Util.normalize_opts(opts)
-      instance = new(id, opts)
+      instance = new(id, **opts)
       instance.refresh
       instance
     end

--- a/lib/telnyx/telnyx_client.rb
+++ b/lib/telnyx/telnyx_client.rb
@@ -310,30 +310,21 @@ module Telnyx
         json_body: resp.data,
       }
 
-      case resp.http_status
-      when 400
-        InvalidRequestError.new(error_list, opts)
-      when 401
-        AuthenticationError.new(error_list, opts)
-      when 403
-        PermissionError.new(error_list, opts)
-      when 404
-        ResourceNotFoundError.new(error_list, opts)
-      when 405
-        MethodNotSupportedError.new(error_list, opts)
-      when 408
-        TimeoutError.new(error_list, opts)
-      when 422
-        InvalidParametersError.new(error_list, opts)
-      when 429
-        RateLimitError.new(error_list, opts)
-      when 500
-        APIError.new(error_list, opts)
-      when 503
-        ServiceUnavailableError.new(error_list, opts)
-      else
-        APIError.new(error_list, opts)
-      end
+      err_class = case resp.http_status
+                  when 400 then InvalidRequestError
+                  when 401 then AuthenticationError
+                  when 403 then PermissionError
+                  when 404 then ResourceNotFoundError
+                  when 405 then MethodNotSupportedError
+                  when 408 then TimeoutError
+                  when 422 then InvalidParametersError
+                  when 429 then RateLimitError
+                  when 500 then APIError
+                  when 503 then ServiceUnavailableError
+                  else APIError
+                  end
+
+      err_class.new(error_list, **opts)
     end
 
     def handle_network_error(e, context, num_retries, api_base = nil)

--- a/telnyx.gemspec
+++ b/telnyx.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/team-telnyx/telnyx-ruby",
   }
 
-  s.add_dependency("faraday", "~> 0.13", "!= 0.16.0", "!= 0.16.1", "!= 0.16.2")
+  s.add_dependency("faraday", "~> 0.13", "!= 0.16.0", "!= 0.16.1", "!= 0.16.2", "!= 0.17.1")
   s.add_dependency("net-http-persistent", "~> 3.0")
   s.add_dependency("ed25519", "~> 1")
 

--- a/test/telnyx/telnyx_object_test.rb
+++ b/test/telnyx/telnyx_object_test.rb
@@ -212,26 +212,26 @@ module Telnyx
 
     should "mass assign values with #update_attributes" do
       obj = Telnyx::TelnyxObject.construct_from(id: 1, name: "Telnyx")
-      obj.update_attributes(name: "telnyx")
+      obj.update_attributes({ name: "telnyx" })
       assert_equal "telnyx", obj.name
 
       # unfortunately, we even assign unknown properties to duplicate the
       # behavior that we currently have via magic accessors with
       # method_missing
-      obj.update_attributes(unknown: "foo")
+      obj.update_attributes({ unknown: "foo" })
       assert_equal "foo", obj.unknown
     end
 
     should "#update_attributes with a hash" do
       obj = Telnyx::TelnyxObject.construct_from({})
-      obj.update_attributes(metadata: { foo: "bar" })
+      obj.update_attributes({ metadata: { foo: "bar" } })
       assert_equal Telnyx::TelnyxObject, obj.metadata.class
     end
 
     should "create accessors when #update_attributes is called" do
       obj = Telnyx::TelnyxObject.construct_from({})
       assert_equal false, obj.send(:metaclass).method_defined?(:foo)
-      obj.update_attributes(foo: "bar")
+      obj.update_attributes({ foo: "bar" })
       assert_equal true, obj.send(:metaclass).method_defined?(:foo)
     end
 
@@ -268,7 +268,7 @@ module Telnyx
 
     should "#serialize_params on a basic object" do
       obj = Telnyx::TelnyxObject.construct_from(foo: nil)
-      obj.update_attributes(foo: "bar")
+      obj.update_attributes({ foo: "bar" })
       assert_equal({ foo: "bar" }, obj.serialize_params)
     end
 


### PR DESCRIPTION
1. Must explicitly pass a hash when a function accepts both keyword
   args and a hash parameter.

2. Must explicitly convert hash to keyword args with ** when passing
   a hash as keyword arguments.